### PR TITLE
Compact images for Fish 2.2.0 and 2.3.0

### DIFF
--- a/fish/2.3.0/Dockerfile
+++ b/fish/2.3.0/Dockerfile
@@ -1,15 +1,14 @@
 FROM alpine:3.4
 
 RUN apk add --no-cache curl g++ git libgcc libstdc++ make mdocml-apropos ncurses ncurses-dev \
-    && curl -OSs http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz \
-    && tar xzf fish-2.2.0.tar.gz \
-    && cd fish-2.2.0 \
-    && sed -i -e '1i #include <sys/select.h>' iothread.cpp \
+    && curl -OSs http://fishshell.com/files/2.3.0/fish-2.3.0.tar.gz \
+    && tar xzf fish-2.3.0.tar.gz \
+    && cd fish-2.3.0 \
     && ./configure \
     && make \
     && make install \
     && cd / \
-    && rm -rf fish-2.2.0 fish-2.2.0.tar.gz \
+    && rm -rf fish-2.3.0 fish-2.3.0.tar.gz \
     && apk del --no-cache g++ make ncurses-dev \
     && fish -c true
 


### PR DESCRIPTION
Replace existing Fish 2.2.0 image with much more compact Alpine image, and that actually installs 2.2.0 always instead of just the latest version 2. Also create a Fish 2.3.0 image with the same configuration.
