### PR TITLE
Add Fish 2.3.1 and add some extra packages

### DIFF
--- a/fish/2.2.0/Dockerfile
+++ b/fish/2.2.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-RUN apk add --no-cache curl g++ git libgcc libstdc++ make mdocml-apropos ncurses ncurses-dev \
+RUN apk add --no-cache curl g++ git groff libgcc libstdc++ make mdocml-apropos ncurses ncurses-dev util-linux \
     && curl -OSs http://fishshell.com/files/2.2.0/fish-2.2.0.tar.gz \
     && tar xzf fish-2.2.0.tar.gz \
     && cd fish-2.2.0 \

--- a/fish/2.3.1/Dockerfile
+++ b/fish/2.3.1/Dockerfile
@@ -1,14 +1,14 @@
 FROM alpine:3.4
 
 RUN apk add --no-cache curl g++ git groff libgcc libstdc++ make mdocml-apropos ncurses ncurses-dev util-linux \
-    && curl -OSs http://fishshell.com/files/2.3.0/fish-2.3.0.tar.gz \
-    && tar xzf fish-2.3.0.tar.gz \
-    && cd fish-2.3.0 \
+    && curl -OSs http://fishshell.com/files/2.3.1/fish-2.3.1.tar.gz \
+    && tar xzf fish-2.3.1.tar.gz \
+    && cd fish-2.3.1 \
     && ./configure \
     && make \
     && make install \
     && cd / \
-    && rm -rf fish-2.3.0 fish-2.3.0.tar.gz \
+    && rm -rf fish-2.3.1 fish-2.3.1.tar.gz \
     && apk del --no-cache g++ make ncurses-dev \
     && fish -c true
 


### PR DESCRIPTION
Added image for Fish 2.3.1. Also, help text was not working without `nroff` and a few extra commands, so added those to each image.
