### PR TITLE
update base image to 3.8 to prevent MITM

### DIFF
--- a/fish/2.7.1/Dockerfile
+++ b/fish/2.7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --no-cache bc curl g++ git groff libgcc libstdc++ make mdocml-apropos ncurses ncurses-dev python sudo util-linux \
     && curl -LOSs https://github.com/fish-shell/fish-shell/releases/download/2.7.1/fish-2.7.1.tar.gz \


### PR DESCRIPTION
related: docker-library/official-images/pull/4834

--- 

Based on https://twitter.com/ahmetb/status/1040322297276522496:

> Scary RCE vulnerability on Alpine base images: 
> - default "apk" repos use plain HTTP 
> - a mitm can silently run arbitrary code during "apk add"
>
> Pull the new alpine:3.8 image and rebuild your stuff. (This is why you should be using "docker build --pull").

More https://justi.cz/security/2018/09/13/alpine-apk-rce.html