### PR TITLE
add fish-3.0.0 dockerfile

### DIFF
--- a/fish/3.0.0/Dockerfile
+++ b/fish/3.0.0/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.8
 
 ARG  FISH_VERSION=3.0.0
+
+RUN curl -Ls https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz | tar -xzf - 
 RUN apk add --no-cache \
     bc \
     curl \
@@ -15,16 +17,15 @@ RUN apk add --no-cache \
     ncurses-dev \
     python \
     sudo \
-    util-linux \
-    && curl -Ls https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz | tar -xzf - \
-    && cd fish-${FISH_VERSION} \
+    util-linux
+RUN cd fish-${FISH_VERSION} \
     && ./configure \
     && make \
-    && make install \
-    && cd / \
+    && make install
+RUN cd / \
     && rm -rf fish-${FISH_VERSION} \
     && apk del --no-cache g++ make ncurses-dev \
-    && fish -c true \
+RUN fish -c true \
     && adduser -D -u 1000 -s /usr/local/bin/fish nemo \
     && echo 'nemo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 

--- a/fish/3.0.0/Dockerfile
+++ b/fish/3.0.0/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:3.8
+
+ARG  FISH_VERSION=3.0.0
+RUN apk add --no-cache \
+    bc \
+    curl \
+    g++ \
+    git \
+    groff \
+    libgcc \
+    libstdc++ \
+    make \
+    mdocml-apropos \
+    ncurses \
+    ncurses-dev \
+    python \
+    sudo \
+    util-linux \
+    && curl -Ls https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz | tar -xzf - \
+    && cd fish-${FISH_VERSION} \
+    && ./configure \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf fish-${FISH_VERSION} \
+    && apk del --no-cache g++ make ncurses-dev \
+    && fish -c true \
+    && adduser -D -u 1000 -s /usr/local/bin/fish nemo \
+    && echo 'nemo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+USER nemo
+WORKDIR /home/nemo
+
+CMD ["fish"]

--- a/fish/3.0.0/Dockerfile
+++ b/fish/3.0.0/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 ARG  FISH_VERSION=3.0.0
 
-RUN echo "Building Fish-${FISH_VERSION}" \
+RUN echo "Building Fish-${FISH_VERSION}"; \
     apk add \
         --no-cache \
         curl \

--- a/fish/3.0.0/Dockerfile
+++ b/fish/3.0.0/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.8
 
 ARG  FISH_VERSION=3.0.0
 
-RUN apk add \
+RUN echo "Building Fish-${FISH_VERSION}" \
+    apk add \
         --no-cache \
         curl \
     && curl \

--- a/fish/3.0.0/Dockerfile
+++ b/fish/3.0.0/Dockerfile
@@ -2,31 +2,49 @@ FROM alpine:3.8
 
 ARG  FISH_VERSION=3.0.0
 
-RUN curl -Ls https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz | tar -xzf - 
-RUN apk add --no-cache \
-    bc \
-    curl \
-    g++ \
-    git \
-    groff \
-    libgcc \
-    libstdc++ \
-    make \
-    mdocml-apropos \
-    ncurses \
-    ncurses-dev \
-    python \
-    sudo \
-    util-linux
+RUN apk add \
+        --no-cache \
+        curl \
+    && curl \
+        --location \
+        --silent \
+    https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz \
+    | tar -xzf - 
+RUN apk add \
+        --no-cache \
+        bc \
+        g++ \
+        git \
+        groff \
+        libgcc \
+        libstdc++ \
+        make \
+        mdocml-apropos \
+        ncurses \
+        ncurses-dev \
+        python \
+        sudo \
+        util-linux
 RUN cd fish-${FISH_VERSION} \
     && ./configure \
     && make \
     && make install
 RUN cd / \
-    && rm -rf fish-${FISH_VERSION} \
-    && apk del --no-cache g++ make ncurses-dev \
+    && rm \
+        -f \
+        -r \
+        fish-${FISH_VERSION} \
+    && apk del \
+            --no-cache \
+            g++ \
+            make \
+            ncurses-dev
 RUN fish -c true \
-    && adduser -D -u 1000 -s /usr/local/bin/fish nemo \
+    && adduser \
+        -D \
+        -u 1000 \
+        -s /usr/local/bin/fish \
+        nemo \
     && echo 'nemo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
 USER nemo


### PR DESCRIPTION
### Using `ARG`
I added an `ARG` directive in order to declare the `fish` version number once, thus speeding up the creation of a new image. This also lets us build a new image through the command line, e.g. imaginary version `7.0.0`:

```
docker build \
      --file ./Dockerfile \
      --tag=fish-7.0.0 \
      --build-arg FISH_VERSION=7.0.0 \
      ./
```
So new image could be based on a single dockerfile (as far as build process stay the same).

Then you can run:
```
docker run \
      --name fish-7.0.0 \
      --rm \
      --tty \
      --interactive \
  fish-7.0.0:latest 
```

### Formatting

* split into multiple directives to better understand the steps required to install ;
* spread command over multiple lines as recommended by docker for better maintanability ;
* use long form options to improve readability.